### PR TITLE
fix: Resolve build error by updating Profile page

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
-import { useProfile } from '@/hooks/useProfile';
+import { useAuth } from '@/hooks/useAuth';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
 import { User, Target, CheckSquare, Building } from 'lucide-react';
@@ -15,7 +15,7 @@ interface AssignedSquare {
 }
 
 const Profile = () => {
-  const { profile, loading: profileLoading } = useProfile();
+  const { profile, loading: profileLoading } = useAuth();
   const [assignedSquares, setAssignedSquares] = useState<AssignedSquare[]>([]);
   const [loading, setLoading] = useState(true);
 


### PR DESCRIPTION
This commit fixes a build error that was caused by the `Profile.tsx` page attempting to import the deleted `useProfile` hook.

- The `Profile.tsx` component has been refactored to use the `useAuth` hook, which is consistent with the rest of the application's recent changes.