### PR TITLE
fix(sidebar): Align collapsed sidebar width

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -21,7 +21,7 @@ const SIDEBAR_COOKIE_NAME = "sidebar:state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "16rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
-const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_WIDTH_ICON = "4rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 
 type SidebarContext = {


### PR DESCRIPTION
The sidebar component had an inconsistency in the width of the collapsed state. The visual component in `AppSidebar.tsx` was set to 4rem (w-16), while the placeholder div in `sidebar.tsx` that pushes the main content was set to 3rem. This caused a 1rem overlap between the main content and the sidebar when collapsed.

This change aligns the collapsed width by updating the `SIDEBAR_WIDTH_ICON` variable in `sidebar.tsx` to 4rem, matching the width defined in `AppSidebar.tsx`. This ensures the placeholder and the visible sidebar have the same width, fixing the layout issue.