### PR TITLE
feat: Implement admin user management

### DIFF
--- a/src/components/AdminUserManagement.tsx
+++ b/src/components/AdminUserManagement.tsx
@@ -1,0 +1,132 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { useToast } from '@/components/ui/use-toast';
+import { Users, Trash2 } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface User {
+  id: string;
+  full_name: string;
+  email: string;
+  role: string;
+}
+
+const AdminUserManagement = () => {
+  const [users, setUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    fetchUsers();
+  }, []);
+
+  const fetchUsers = async () => {
+    try {
+      // The rpc call is needed to join with auth.users to get the email
+      const { data, error } = await supabase.rpc('get_users_with_email');
+
+      if (error) throw error;
+      setUsers(data || []);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "خطأ في تحميل المستخدمين";
+      toast({ variant: "destructive", title: "خطأ", description: message });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRoleChange = async (userId: string, newRole: string) => {
+    try {
+      const { error } = await supabase
+        .from('profiles')
+        .update({ role: newRole })
+        .eq('id', userId);
+
+      if (error) throw error;
+      toast({ title: "تم بنجاح", description: "تم تحديث دور المستخدم بنجاح." });
+      fetchUsers(); // Refresh the list
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "خطأ في تحديث الدور";
+      toast({ variant: "destructive", title: "خطأ", description: message });
+    }
+  };
+
+  const handleDeleteUser = async (userId: string) => {
+    // Note: Deleting a user from auth.users is a protected operation
+    // and should be handled with a server-side function with service_role key.
+    // This is a placeholder for now.
+    toast({ variant: "default", title: "قيد الإنشاء", description: "حذف المستخدم قيد الإنشاء" });
+    console.log("Delete user:", userId);
+  };
+
+  if (loading) {
+    return <div>جاري تحميل المستخدمين...</div>;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Users className="w-5 h-5 text-primary" />
+          إدارة المستخدمين
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>الاسم الكامل</TableHead>
+              <TableHead>البريد الإلكتروني</TableHead>
+              <TableHead>الدور</TableHead>
+              <TableHead>الإجراءات</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((user) => (
+              <TableRow key={user.id}>
+                <TableCell>{user.full_name}</TableCell>
+                <TableCell>{user.email}</TableCell>
+                <TableCell>
+                  <Select
+                    value={user.role}
+                    onValueChange={(newRole) => handleRoleChange(user.id, newRole)}
+                  >
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue placeholder="اختر دورًا" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="admin">مسؤول</SelectItem>
+                      <SelectItem value="representative">مندوب</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => handleDeleteUser(user.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default AdminUserManagement;

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -4,17 +4,16 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useToast } from '@/components/ui/use-toast';
-import { Shield, Users, DollarSign, MapPin, Target, Building, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Shield, Users, DollarSign, MapPin, Target, Building, UserCog } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import AdminTeamManager from '@/components/AdminTeamManager';
 import AdminBudgetManager from '@/components/AdminBudgetManager';
 import AdminDistrictsManager from '@/components/AdminDistrictsManager';
 import AdminStrategyManager from '@/components/AdminStrategyManager';
 import AdminAssignmentManager from '@/components/AdminAssignmentManager';
+import AdminUserManagement from '@/components/AdminUserManagement';
 
 const Admin = () => {
-  const { toast } = useToast();
-
   return (
     <div className="space-y-6" dir="rtl">
       <Card className="border-primary/20">
@@ -28,7 +27,11 @@ const Admin = () => {
       </Card>
 
       <Tabs defaultValue="assignments" className="space-y-6">
-        <TabsList className="grid w-full grid-cols-5">
+        <TabsList className="grid w-full grid-cols-6">
+          <TabsTrigger value="users" className="flex items-center gap-2">
+            <UserCog className="w-4 h-4" />
+            المستخدمين
+          </TabsTrigger>
           <TabsTrigger value="assignments" className="flex items-center gap-2">
             <Building className="w-4 h-4" />
             التعيينات
@@ -50,6 +53,10 @@ const Admin = () => {
             الاستراتيجية
           </TabsTrigger>
         </TabsList>
+
+        <TabsContent value="users">
+          <AdminUserManagement />
+        </TabsContent>
 
         <TabsContent value="assignments">
           <AdminAssignmentManager />

--- a/supabase/migrations/20250909014757_create_get_users_with_email_function.sql
+++ b/supabase/migrations/20250909014757_create_get_users_with_email_function.sql
@@ -1,0 +1,15 @@
+CREATE OR REPLACE FUNCTION public.get_users_with_email()
+RETURNS TABLE(id uuid, full_name text, email text, role text)
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+  SELECT
+    p.id,
+    p.full_name,
+    u.email,
+    p.role
+  FROM
+    public.profiles p
+  JOIN
+    auth.users u ON p.id = u.id;
+$$;


### PR DESCRIPTION
This commit introduces a new feature for admin user management.

- Creates a new `AdminUserManagement` component to display and manage users.
- Adds a new tab to the admin page for user management.
- Implements functionality to change user roles (admin/representative).
- Creates a new Supabase RPC function `get_users_with_email` to fetch user data securely.
- The user deletion functionality is included as a placeholder and will be implemented in a future update.